### PR TITLE
Fixed bug in fill_triangle for flat topped triangles

### DIFF
--- a/adafruit_gfx/gfx.py
+++ b/adafruit_gfx/gfx.py
@@ -276,7 +276,7 @@ class GFX:
             dy12 = 1
         sa = 0
         sb = 0
-        if y1 == y2:
+        if y1 == y2 or y0 == y1:
             last = y1
         else:
             last = y1 - 1

--- a/adafruit_gfx/gfx.py
+++ b/adafruit_gfx/gfx.py
@@ -276,7 +276,7 @@ class GFX:
             dy12 = 1
         sa = 0
         sb = 0
-        if y1 == y2 or y0 == y1:
+        if y1 == y2 or y0 == y1:  # pylint: disable=consider-using-in
             last = y1
         else:
             last = y1 - 1


### PR DESCRIPTION
Fix for this bug: https://github.com/adafruit/Adafruit_CircuitPython_GFX/issues/2

If y0 was equal to y1, the loop on line 283 was being skipped meaning y was 0 when getting to the loop on line 293, resulting in a much bigger triangle being drawn starting from y = 0.

