### PR TITLE
fix fill_triangle bug issue #33

### DIFF
--- a/adafruit_gfx/gfx.py
+++ b/adafruit_gfx/gfx.py
@@ -25,6 +25,7 @@ Implementation Notes
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_GFX.git"
 
+
 # pylint: disable=invalid-name
 class GFX:
     # pylint: disable=too-many-instance-attributes
@@ -49,6 +50,7 @@ class GFX:
     :param font: An optional input to augment the default text method with a new font.
                   The input should be a properly formatted dict.
     """
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -280,7 +282,7 @@ class GFX:
             last = y1 - 1
         else:
             last = y1
-        while y <= last: 
+        while y <= last:
             a = x0 + sa // dy01
             b = x0 + sb // dy02
             sa += dx01
@@ -304,7 +306,8 @@ class GFX:
     def round_rect(self, x0, y0, width, height, radius, *args, **kwargs):
         """Rectangle with rounded corners drawing function.
         This works like a regular rect though! if radius = 0
-        Will draw the outline of a rectangle with rounded corners with (x0,y0) at the top left"""
+        Will draw the outline of a rectangle with rounded corners with (x0,y0) at the top left
+        """
         # shift to correct for start point location
         x0 += radius
         y0 += radius

--- a/adafruit_gfx/gfx.py
+++ b/adafruit_gfx/gfx.py
@@ -247,7 +247,6 @@ class GFX:
             x0, x1 = x1, x0
         a = 0
         b = 0
-        y = 0
         last = 0
         if y0 == y2:
             a = x0
@@ -276,11 +275,12 @@ class GFX:
             dy12 = 1
         sa = 0
         sb = 0
-        if y1 == y2 or y0 == y1:  # pylint: disable=consider-using-in
-            last = y1
-        else:
+        y = y0
+        if y0 == y1:
             last = y1 - 1
-        for y in range(y0, last + 1):
+        else:
+            last = y1
+        while y <= last: 
             a = x0 + sa // dy01
             b = x0 + sb // dy02
             sa += dx01
@@ -288,6 +288,7 @@ class GFX:
             if a > b:
                 a, b = b, a
             self.hline(a, y, b - a + 1, *args, **kwargs)
+            y += 1
         sa = dx12 * (y - y1)
         sb = dx02 * (y - y0)
         while y <= y2:


### PR DESCRIPTION
This fix for issue #33 replaces the for loop at lines 283 to 291 with a while loop so that the y variable is properly incremented between the loops to fill the top and bottom parts of the triangle. This avoids screen row at y0 being drawn twice, and corrects the shape of the triangle. The changes to lines 278 to 282 (as numbered after the fix) initiate the two loops in a way that addresses issue #22 where a triangle with a flat bottom edge was not drawn correctly.

This fix has been implemented in the derived repository  [framebuf2](https://github.com/peter-l5/framebuf2) which applies the algorithm here and has been  tested with the following code. (Note that `f=True` parameter draws a filled triangle in this implementation.)
```
    for z in range(3,123+1,20):
        for x in range(10,120+1,20):
            for y in range(0,128):
                display.fill(0)
                display.triangle(x,y,30,z,90,63,c=1,f=True)
                display.show()
```